### PR TITLE
Change default value for COMMUTER_S3_ENDPOINT from empty string to null

### DIFF
--- a/src/backend/config.js
+++ b/src/backend/config.js
@@ -42,7 +42,7 @@ function populateS3Options(env): Object {
     .replace(/\/+$/, "");
 
   const s3Endpoint =
-    env.COMMUTER_S3_ENDPOINT || "";
+    env.COMMUTER_S3_ENDPOINT || null;
   
   // only interpret "true" as true otherwise false
   const s3ForcePathStyle = /^true$/i.test(


### PR DESCRIPTION
I encountered the same issue as reported in https://github.com/nteract/commuter/issues/298.

I'm setting the following environment variables:
```
COMMUTER_S3_KEY=<key>
COMMUTER_S3_SECRET=<secret>
COMMUTER_BUCKET=<bucket>
COMMUTER_STORAGE_BACKEND=s3
```

I independently tested that I have List and Get permissions on the bucket in question using `awscli`.

Below is the full stack trace that I receive when accessing `/view`. What stood out is the empty string that comes after the `<bucket>.`. As soon as I changed the default from `""` to `null` as per @elvinx's suggestion, it worked for me!

```
getaddrinfo ENOTFOUND <bucket>.
```

```
[Error [AjaxError]: ajax error 500] { 
  xhr: { 
    UNSENT: 0, 
    OPENED: 1, 
    HEADERS_RECEIVED: 2, 
    LOADING: 3, 
    DONE: 4, 
    readyState: 4, 
    onreadystatechange: [Function: xhrReadyStateChange] { 
      subscriber: [AjaxSubscriber], 
      progressSubscriber: undefined, 
      request: [Object] 
    }, 
    responseText: '{"message":"getaddrinfo ENOTFOUND <bucket>.: ","reason":"NetworkingError"}', 
    responseXML: '', 
    status: 500, 
    statusText: null, 
    withCredentials: false, 
    open: [Function (anonymous)], 
    setDisableHeaderCheck: [Function (anonymous)], 
    setRequestHeader: [Function (anonymous)], 
    getResponseHeader: [Function (anonymous)], 
    getAllResponseHeaders: [Function (anonymous)], 
    getRequestHeader: [Function (anonymous)], 
    send: [Function (anonymous)], 
    handleError: [Function (anonymous)], 
    abort: [Function (anonymous)], 
    addEventListener: [Function (anonymous)], 
    removeEventListener: [Function (anonymous)], 
    dispatchEvent: [Function (anonymous)], 
    ontimeout: [Function: xhrTimeout] { 
      request: [Object], 
      subscriber: [AjaxSubscriber], 
      progressSubscriber: undefined 
    }, 
    onload: [Function: xhrLoad] { 
      subscriber: [AjaxSubscriber], 
      progressSubscriber: undefined, 
      request: [Object] 
    }, 
    timeout: 0, 
    responseType: 'json' 
  }, 
  request: { 
    async: true, 
    createXHR: [Function: createXHR], 
    crossDomain: true, 
    withCredentials: false, 
    headers: {}, 
    method: 'GET', 
    responseType: 'json', 
    timeout: 0, 
    url: 'http://127.0.0.1:4000/api/contents//', 
    body: undefined 
  }, 
  status: 500, 
  responseType: 'json', 
  response: { 
    message: 'getaddrinfo ENOTFOUND <bucket>.: ', 
    reason: 'NetworkingError' 
  } 
} 
```